### PR TITLE
Update volume definition to match config

### DIFF
--- a/examples/auth-enabled/docker-compose.yml
+++ b/examples/auth-enabled/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5000:5000
     volumes:
       - ./conf/registry:/etc/docker/registry:ro
-      - ./registry:/var/lib/registry
+      - ./registry:/registry
     networks:
       - registry-net
 

--- a/examples/nginx-auth-enabled/docker-compose.yml
+++ b/examples/nginx-auth-enabled/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - 127.0.0.1:5000:5000
     volumes:
       - ./conf/registry:/etc/docker/registry:ro
-      - ./registry:/var/lib/registry
+      - ./registry:/registry
     networks:
       - registry-net
 


### PR DESCRIPTION
The config of the repository lists /repository, not /var/lib/repository as the root folder